### PR TITLE
chore: Update android libs again and bump to 0.0.38

### DIFF
--- a/androidprecompiled/libpdfium.a
+++ b/androidprecompiled/libpdfium.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8df78de9e854a86247c57459f27bb2d0e21af82bb355f6ec5b37436683b2256
-size 23169418
+oid sha256:0ecac2016ca702f8e1094d9fa519552a6f1151e3f08638436d7c2f6e1d5e2d9a
+size 14911866

--- a/qpm.json
+++ b/qpm.json
@@ -10,7 +10,7 @@
     "url": "git@github.com:reMarkable/pdfium-qmake.git"
   },
   "version": {
-    "label": "0.0.37",
+    "label": "0.0.38",
     "revision": "",
     "fingerprint": ""
   },


### PR DESCRIPTION
Seems that the android binary was incorrect. Trying again.